### PR TITLE
Upgrade to 1.0.93

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = joplin
 	pkgdesc = Joplin - a note taking and to-do application with synchronization capabilities for Windows, macOS, Linux, Android and iOS.
-	pkgver = 1.0.85
+	pkgver = 1.0.93
 	pkgrel = 1
 	url = https://joplin.cozic.net
 	arch = x86_64
@@ -16,11 +16,11 @@ pkgbase = joplin
 	source = joplin.desktop
 	source = joplin-desktop.sh
 	source = joplin.sh
-	source = https://github.com/laurent22/joplin/archive/v1.0.85.zip
+	source = https://github.com/laurent22/joplin/archive/v1.0.93.zip
 	sha256sums = 9ee4a831a0853ddbdc7279629d8f9238d3737b570898be16176ba0968b53d43d
 	sha256sums = 5a3ace64906080adde5a5ea10ec9221fb2d94de770e6ee35b454aa30608b4097
 	sha256sums = 5e3424162814db56718b01740af1ef7c9b30e00f563040456eeb8b7eaca81427
-	sha256sums = 38454cec2ecba0428b5c3214ce90ca945d8191ce5e13826933905adda88c79fa
+	sha256sums = cea54de90c2623258e5d3e95fcca455b190bed10b1b162baff15f579eda1530b
 
 pkgname = joplin
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@
 # https://github.com/masterkorp/joplin-pkgbuild
 
 pkgname=joplin
-pkgver=1.0.85
+pkgver=1.0.93
 pkgrel=1
 pkgdesc="Joplin - a note taking and to-do application with synchronization capabilities for Windows, macOS, Linux, Android and iOS."
 arch=("x86_64" "i686")
@@ -18,7 +18,7 @@ source=("${pkgname}.desktop" "joplin-desktop.sh" "joplin.sh"
 sha256sums=("9ee4a831a0853ddbdc7279629d8f9238d3737b570898be16176ba0968b53d43d"
             "5a3ace64906080adde5a5ea10ec9221fb2d94de770e6ee35b454aa30608b4097"
             "5e3424162814db56718b01740af1ef7c9b30e00f563040456eeb8b7eaca81427"
-            "38454cec2ecba0428b5c3214ce90ca945d8191ce5e13826933905adda88c79fa")
+            "cea54de90c2623258e5d3e95fcca455b190bed10b1b162baff15f579eda1530b")
 
 build() {
 


### PR DESCRIPTION
I had some issues with joplin concerning synchronization with the previous version, so I upgraded the PKGBUILD locally and thought I'd do a pull request.

Latest release: https://github.com/laurent22/joplin/releases/tag/v1.0.93