### PR TITLE
Upgrade to 1.0.111

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = joplin
 	pkgdesc = Joplin - a note taking and to-do application with synchronization capabilities for Windows, macOS, Linux, Android and iOS.
-	pkgver = 1.0.106
+	pkgver = 1.0.111
 	pkgrel = 1
 	url = https://joplin.cozic.net
 	arch = x86_64
@@ -17,11 +17,11 @@ pkgbase = joplin
 	source = joplin.desktop
 	source = joplin-desktop.sh
 	source = joplin.sh
-	source = https://github.com/laurent22/joplin/archive/v1.0.106.zip
+	source = https://github.com/laurent22/joplin/archive/v1.0.111.zip
 	sha256sums = 9ee4a831a0853ddbdc7279629d8f9238d3737b570898be16176ba0968b53d43d
 	sha256sums = 5a3ace64906080adde5a5ea10ec9221fb2d94de770e6ee35b454aa30608b4097
 	sha256sums = 5e3424162814db56718b01740af1ef7c9b30e00f563040456eeb8b7eaca81427
-	sha256sums = 254a457838c28d1a188aac164f2c2ca2864e0261117cd01c34ca2e4890d26f79
+	sha256sums = 0f09ddad70c7795c1cd557e884a4a253e5fbe7dd66bda268dd77fb9705954dcc
 
 pkgname = joplin
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@
 # https://github.com/masterkorp/joplin-pkgbuild
 
 pkgname=joplin
-pkgver=1.0.106
+pkgver=1.0.111
 pkgrel=1
 pkgdesc="Joplin - a note taking and to-do application with synchronization capabilities for Windows, macOS, Linux, Android and iOS."
 arch=("x86_64" "i686")
@@ -18,7 +18,7 @@ source=("${pkgname}.desktop" "joplin-desktop.sh" "joplin.sh"
 sha256sums=("9ee4a831a0853ddbdc7279629d8f9238d3737b570898be16176ba0968b53d43d"
             "5a3ace64906080adde5a5ea10ec9221fb2d94de770e6ee35b454aa30608b4097"
             "5e3424162814db56718b01740af1ef7c9b30e00f563040456eeb8b7eaca81427"
-            "254a457838c28d1a188aac164f2c2ca2864e0261117cd01c34ca2e4890d26f79")
+            "0f09ddad70c7795c1cd557e884a4a253e5fbe7dd66bda268dd77fb9705954dcc")
 
 build() {
 


### PR DESCRIPTION
Just bumping to the latest `joplin-1.0.111` that has been released recently.

[Release notes here](https://github.com/laurent22/joplin/releases/tag/v1.0.111).